### PR TITLE
Fix deprecation warning by explicitly capturing block

### DIFF
--- a/lib/rake/release/task.rb
+++ b/lib/rake/release/task.rb
@@ -203,12 +203,12 @@ module Rake
       end
 
       class << self
-        def load_all(dir = pwd)
+        def load_all(dir = pwd, &block)
           specs = Spec.scan dir.join('**/*.gemspec')
 
           specs.each {|spec| spec.namespace = spec.name } if specs.size > 1
 
-          specs.each(&Proc.new) if block_given?
+          specs.each(&block) if block
 
           if specs.uniq {|s| s.namespace.to_s.strip }.size != specs.size
             raise 'Non distinct release task namespaces'


### PR DESCRIPTION
I noticed this warning in CI running Ruby 2.7:

```
rake-release-1.2.1/lib/rake/release/task.rb:211: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

Refs:
- https://github.com/ruby/ruby/commit/9f1fb0a17febc59356d58cef5e98db61a3c03550
- https://bugs.ruby-lang.org/issues/15539

Instead of having `Proc.new` capturing the method's block, this just explicitly captures it.